### PR TITLE
Quick hack to fix CT tests

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,6 +12,6 @@
             warnings_as_errors,
             {platform_define, "^[0-9]+", namespaced_types},
             {parse_transform, lager_transform}]}.
-{cover_enabled, false}.
+{cover_enabled, true}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.
 {edoc_opts, [{preprocess, true}]}.

--- a/src/plumtree_broadcast.erl
+++ b/src/plumtree_broadcast.erl
@@ -18,6 +18,7 @@
 %%
 %% -------------------------------------------------------------------
 -module(plumtree_broadcast).
+-compile({parse_transform, lager_transform}).
 
 -behaviour(gen_server).
 

--- a/src/plumtree_metadata_exchange_fsm.erl
+++ b/src/plumtree_metadata_exchange_fsm.erl
@@ -18,6 +18,7 @@
 %%
 %% -------------------------------------------------------------------
 -module(plumtree_metadata_exchange_fsm).
+-compile({parse_transform, lager_transform}).
 
 -behaviour(gen_fsm).
 

--- a/src/plumtree_metadata_hashtree.erl
+++ b/src/plumtree_metadata_hashtree.erl
@@ -18,6 +18,7 @@
 %%
 %% -------------------------------------------------------------------
 -module(plumtree_metadata_hashtree).
+-compile({parse_transform, lager_transform}).
 
 -behaviour(gen_server).
 

--- a/src/plumtree_metadata_manager.erl
+++ b/src/plumtree_metadata_manager.erl
@@ -18,6 +18,7 @@
 %%
 %% -------------------------------------------------------------------
 -module(plumtree_metadata_manager).
+-compile({parse_transform, lager_transform}).
 
 -behaviour(gen_server).
 -behaviour(plumtree_broadcast_handler).

--- a/src/plumtree_peer_service.erl
+++ b/src/plumtree_peer_service.erl
@@ -19,6 +19,7 @@
 %% -------------------------------------------------------------------
 
 -module(plumtree_peer_service).
+-compile({parse_transform, lager_transform}).
 
 -export([join/1,
          join/2,

--- a/src/plumtree_peer_service_gossip.erl
+++ b/src/plumtree_peer_service_gossip.erl
@@ -19,6 +19,7 @@
 %% -------------------------------------------------------------------
 
 -module(plumtree_peer_service_gossip).
+-compile({parse_transform, lager_transform}).
 
 -behavior(gen_server).
 

--- a/src/plumtree_peer_service_manager.erl
+++ b/src/plumtree_peer_service_manager.erl
@@ -19,6 +19,7 @@
 %% -------------------------------------------------------------------
 
 -module(plumtree_peer_service_manager).
+-compile({parse_transform, lager_transform}).
 
 -behaviour(gen_server).
 

--- a/test/cluster_membership_SUITE.erl
+++ b/test/cluster_membership_SUITE.erl
@@ -19,6 +19,7 @@
 %% -------------------------------------------------------------------
 
 -module(cluster_membership_SUITE).
+-compile({parse_transform, lager_transform}).
 
 -compile({parse_transform, lager_transform}).
 
@@ -70,7 +71,7 @@ init_per_testcase(Case, Config) ->
     Nodes = plumtree_test_utils:pmap(fun(N) ->
                     plumtree_test_utils:start_node(N, Config, Case)
             end, [jaguar, shadow, thorn, pyros]),
-    {ok, _} = ct_cover:add_nodes(Nodes),
+    %%%%%%%%%%%%%%%%%%%%%%%%%% {ok, _} = ct_cover:add_nodes(Nodes),
     [{nodes, Nodes}|Config].
 
 end_per_testcase(_, _Config) ->
@@ -83,7 +84,7 @@ all() ->
 
 singleton_test(Config) ->
     Nodes = proplists:get_value(nodes, Config),
-    ok = ct_cover:remove_nodes(Nodes),
+    %%%%%%%%%%%%%%%%%%%%%%%%%% ok = ct_cover:remove_nodes(Nodes),
     [[Node] = plumtree_test_utils:get_cluster_members(Node) || Node <- Nodes],
     ok.
 

--- a/test/metadata_SUITE.erl
+++ b/test/metadata_SUITE.erl
@@ -19,6 +19,7 @@
 %% -------------------------------------------------------------------
 
 -module(metadata_SUITE).
+-compile({parse_transform, lager_transform}).
 
 -compile({parse_transform, lager_transform}).
 
@@ -66,7 +67,7 @@ init_per_testcase(Case, Config) ->
     Nodes = plumtree_test_utils:pmap(fun(N) ->
                     plumtree_test_utils:start_node(N, Config, Case)
             end, [electra, katana, flail, gargoyle]),
-    {ok, _} = ct_cover:add_nodes(Nodes),
+    %%%%%%%%%%%%%%%%%%%%%%%%%% {ok, _} = ct_cover:add_nodes(Nodes),
     [{nodes, Nodes}|Config].
 
 end_per_testcase(_, _Config) ->


### PR DESCRIPTION
It's ugly, but it's an improvement.

```
Testing erlang.plumtree: TEST COMPLETE, 10 ok, 0 failed of 10 test cases
```
