### PR TITLE
remove deprecated maintainers hex metadata

### DIFF
--- a/src/plumtree.app.src
+++ b/src/plumtree.app.src
@@ -6,7 +6,5 @@
               {mod,{plumtree_app,[]}},
               {modules,[]},
               {env,[{plumtree_data_dir,"data"}]},
-              {maintainers,["Chris Meiklejohn","Tom Santero",
-                            "Andrew Thompson"]},
               {licenses,["Apache 2.0"]},
               {links,[{"Github","https://github.com/lasp-lang/plumtree"}]}]}.


### PR DESCRIPTION
This information is now based on who publishes the package and who has permission to publish the package.