### PR TITLE
OTP 24 support - no lager dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,15 +1,14 @@
 {min_otp_version, "19.0"}.
 
 {deps, [{lasp_support, "~>0.1"},
-        {partisan, "~>4.1"},
-        {lager, "~>3.5"}]}.
+        {partisan, {git, "https://github.com/Inkwell-Data/partisan.git", {branch, "no_lager"}}}
+      ]}.
 
 {dialyzer_base_plt_apps, [kernel, stdlib, erts, sasl, eunit, syntax_tools, compiler, crypto]}.
 {xref_checks, [undefined_function_calls]}.
 {erl_opts, [debug_info,
             warnings_as_errors,
-            {platform_define, "^[0-9]+", namespaced_types},
-            {parse_transform, lager_transform}]}.
+            {platform_define, "^[0-9]+", namespaced_types}]}.
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.
 {edoc_opts, [{preprocess, true}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,22 +3,23 @@
  {<<"lasp_support">>,{pkg,<<"lasp_support">>,<<"0.1.0">>},0},
  {<<"partisan">>,
   {git,"https://github.com/Inkwell-Data/partisan.git",
-       {ref,"8a0338316f0599873a979bd9bf9913b528009961"}},
+       {ref,"ea21a06c944892ebd9083bbca01ec98c14fae894"}},
   0},
- {<<"quickrand">>,{pkg,<<"quickrand">>,<<"1.7.5">>},2},
- {<<"types">>,{pkg,<<"types">>,<<"0.1.8">>},1},
- {<<"uuid">>,{pkg,<<"uuid_erl">>,<<"1.7.5">>},1}]}.
+ {<<"quickrand">>,{pkg,<<"quickrand">>,<<"2.0.2">>},2},
+ {<<"types">>,
+  {git,"https://github.com/Inkwell-Data/types.git",
+       {ref,"8cfaeb1bd7a0983db62d1ed3129e7cab91239ff6"}},
+  1},
+ {<<"uuid">>,{pkg,<<"uuid_erl">>,<<"2.0.1">>},1}]}.
 [
 {pkg_hash,[
  {<<"acceptor_pool">>, <<"43C20D2ACAE35F0C2BCD64F9D2BDE267E459F0F3FD23DAB26485BF518C281B21">>},
  {<<"lasp_support">>, <<"A6D665138BD8C10555FE7A4A2A81A8A47079EAE5FFC368D411DE660EB7A66F04">>},
- {<<"quickrand">>, <<"E3086A153EB13A057FC19192D05E2D4C6BB2BDBB55746A699BEAE9847AC17CA8">>},
- {<<"types">>, <<"5782B67231E8C174FE2835395E71E669FE0121076779D2A09F1C0D58EE0E2F13">>},
- {<<"uuid">>, <<"3862FF9A21C42566DFD0376B97512FA202922897129E09A05E2AFA0D9CAFD97A">>}]},
+ {<<"quickrand">>, <<"1D73FAA52E0C149FCBC72A63C26135FF68BE8FA7870675C73645896788A7540C">>},
+ {<<"uuid">>, <<"1FD9079C544D521063897887A1C5B3302DCA98F9BB06AADCDC6FB0663F256797">>}]},
 {pkg_hash_ext,[
  {<<"acceptor_pool">>, <<"0CBCD83FDC8B9AD2EEE2067EF8B91A14858A5883CB7CD800E6FCD5803E158788">>},
  {<<"lasp_support">>, <<"D57A85BA77607BB097CE4B9DD233E29C98C4824468D1A7BE06C9C6C15D8618F8">>},
- {<<"quickrand">>, <<"6A1DA81FE098C0DFCFB55C5E35C20BE430128E88BBFA03D18FCF9E0EE8E342D7">>},
- {<<"types">>, <<"04285239F4954C5EDE56F78ED7778EDE24E3F2E997F7B16402A167AF0CC2658A">>},
- {<<"uuid">>, <<"6529F1C5D8C6B796374318FD1966659FAA6EE832C914E93B1DEB1D4701694AA9">>}]}
+ {<<"quickrand">>, <<"E21C6C7F29CA995468662085CA54D7D09E861C180A9DFEC2CF4A2E75364A16D6">>},
+ {<<"uuid">>, <<"AB57CACCD51F170011E5F444CE865F84B41605E483A9EFCC468C1AFAEC87553B">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,20 +1,24 @@
-{"1.1.0",
+{"1.2.0",
 [{<<"acceptor_pool">>,{pkg,<<"acceptor_pool">>,<<"1.0.0">>},1},
- {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
- {<<"lager">>,{pkg,<<"lager">>,<<"3.8.0">>},0},
  {<<"lasp_support">>,{pkg,<<"lasp_support">>,<<"0.1.0">>},0},
- {<<"partisan">>,{pkg,<<"partisan">>,<<"4.1.0">>},0},
+ {<<"partisan">>,
+  {git,"https://github.com/Inkwell-Data/partisan.git",
+       {ref,"8a0338316f0599873a979bd9bf9913b528009961"}},
+  0},
  {<<"quickrand">>,{pkg,<<"quickrand">>,<<"1.7.5">>},2},
  {<<"types">>,{pkg,<<"types">>,<<"0.1.8">>},1},
  {<<"uuid">>,{pkg,<<"uuid_erl">>,<<"1.7.5">>},1}]}.
 [
 {pkg_hash,[
  {<<"acceptor_pool">>, <<"43C20D2ACAE35F0C2BCD64F9D2BDE267E459F0F3FD23DAB26485BF518C281B21">>},
- {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
- {<<"lager">>, <<"3402B9A7E473680CA179FC2F1D827CAB88DD37DD1E6113090C6F45EF05228A1C">>},
  {<<"lasp_support">>, <<"A6D665138BD8C10555FE7A4A2A81A8A47079EAE5FFC368D411DE660EB7A66F04">>},
- {<<"partisan">>, <<"51D3C1D6487BBB8F94D4FD313D03D93F1C0426350A3ADF84CC3B3243B8EA204E">>},
  {<<"quickrand">>, <<"E3086A153EB13A057FC19192D05E2D4C6BB2BDBB55746A699BEAE9847AC17CA8">>},
  {<<"types">>, <<"5782B67231E8C174FE2835395E71E669FE0121076779D2A09F1C0D58EE0E2F13">>},
- {<<"uuid">>, <<"3862FF9A21C42566DFD0376B97512FA202922897129E09A05E2AFA0D9CAFD97A">>}]}
+ {<<"uuid">>, <<"3862FF9A21C42566DFD0376B97512FA202922897129E09A05E2AFA0D9CAFD97A">>}]},
+{pkg_hash_ext,[
+ {<<"acceptor_pool">>, <<"0CBCD83FDC8B9AD2EEE2067EF8B91A14858A5883CB7CD800E6FCD5803E158788">>},
+ {<<"lasp_support">>, <<"D57A85BA77607BB097CE4B9DD233E29C98C4824468D1A7BE06C9C6C15D8618F8">>},
+ {<<"quickrand">>, <<"6A1DA81FE098C0DFCFB55C5E35C20BE430128E88BBFA03D18FCF9E0EE8E342D7">>},
+ {<<"types">>, <<"04285239F4954C5EDE56F78ED7778EDE24E3F2E997F7B16402A167AF0CC2658A">>},
+ {<<"uuid">>, <<"6529F1C5D8C6B796374318FD1966659FAA6EE832C914E93B1DEB1D4701694AA9">>}]}
 ].

--- a/src/plumtree.app.src
+++ b/src/plumtree.app.src
@@ -2,7 +2,7 @@
              [{description,"Epidemic Broadcast Trees"},
               {vsn,"0.6.0"},
               {registered,[]},
-              {applications,[kernel,stdlib,crypto,lager,partisan]},
+              {applications,[kernel,stdlib,crypto,partisan]},
               {mod,{plumtree_app,[]}},
               {modules,[]},
               {env,[{plumtree_data_dir,"data"}]},

--- a/src/plumtree_broadcast.erl
+++ b/src/plumtree_broadcast.erl
@@ -186,7 +186,7 @@ update(LocalState0) ->
                                       peer_service,
                                       partisan_peer_service),
     LocalState = PeerService:decode(LocalState0),
-    % lager:info("Update triggered with: ~p", [LocalState]),
+    % logger:info("Update triggered with: ~p", [LocalState]),
     gen_server:cast(?SERVER, {update, LocalState}).
 
 %% @doc Returns the broadcast servers view of full cluster membership.
@@ -405,7 +405,7 @@ handle_graft({ok, Message}, MessageId, Mod, Round, Root, From, State) ->
     _ = send({broadcast, MessageId, Message, Mod, Round, Root, myself()}, Mod, From),
     State1;
 handle_graft({error, Reason}, _MessageId, Mod, _Round, _Root, _From, State) ->
-    lager:error("unable to graft message from ~p. reason: ~p", [Mod, Reason]),
+    logger:error("unable to graft message from ~p. reason: ~p", [Mod, Reason]),
     State.
 
 neighbors_down(Removed, State) ->
@@ -686,7 +686,7 @@ instrument_transmission(Message, Mod) ->
                 Mod:extract_log_type_and_payload(Message)
             catch
                 _:Error ->
-                    lager:info("Couldn't extract log type and payload. Reason ~p", [Error]),
+                    logger:info("Couldn't extract log type and payload. Reason ~p", [Error]),
                     []
             end,
 

--- a/src/plumtree_util.erl
+++ b/src/plumtree_util.erl
@@ -58,11 +58,11 @@ log(Level, String) ->
     log(Level, String, []).
 
 log(debug, String, Args) ->
-    lager:debug(String, Args);
+    logger:debug(String, Args);
 log(info, String, Args) ->
-    lager:info(String, Args);
+    logger:info(String, Args);
 log(error, String, Args) ->
-    lager:error(String, Args).
+    logger:error(String, Args).
 
 -else.
 

--- a/test/plumtree_test_broadcast_handler.erl
+++ b/test/plumtree_test_broadcast_handler.erl
@@ -55,11 +55,11 @@ start_link() ->
 read(Key) ->
     case ets:lookup(?MODULE, Key) of
         [{Key, Value}] ->
-            % lager:info("read key ~p: ~p",
+            % logger:info("read key ~p: ~p",
             %            [Key, Value]),
             {ok, Value};
         _ ->
-            lager:info("unable to find key: ~p",
+            logger:info("unable to find key: ~p",
                        [Key]),
             {error, not_found}
     end.
@@ -113,7 +113,7 @@ code_change(_OldVsn, State, _Extra) ->
 -spec broadcast_data(any()) -> {any(), any()}.
 broadcast_data({Key, _Value} = Data) ->
     MsgId = erlang:phash2(Data),
-    lager:info("broadcast_data(~p), msg id: ~p",
+    logger:info("broadcast_data(~p), msg id: ~p",
                [Data, MsgId]),
     true = ets:insert(msgs_seen, {MsgId, Key}),
     true = ets:insert(?MODULE, Data),
@@ -125,11 +125,11 @@ broadcast_data({Key, _Value} = Data) ->
 merge(MsgId, {Key, _Value} = Payload) ->
     case ets:lookup(msgs_seen, MsgId) of
         [{MsgId, _}] ->
-            lager:info("msg with id ~p has already been seen",
+            logger:info("msg with id ~p has already been seen",
                       [MsgId]),
             false;
         _ ->
-            lager:info("merging(~p, ~p) in local state",
+            logger:info("merging(~p, ~p) in local state",
                        [MsgId, Payload]),
             %% insert the message in the local state
             true = ets:insert(?MODULE, Payload),
@@ -144,11 +144,11 @@ merge(MsgId, {Key, _Value} = Payload) ->
 is_stale(MsgId) ->
     case ets:lookup(msgs_seen, MsgId) of
         [{MsgId, _}] ->
-            lager:info("is_stale(~p): ~p",
+            logger:info("is_stale(~p): ~p",
                        [MsgId, true]),
             true;
         _ ->
-            lager:info("is_stale(~p): ~p",
+            logger:info("is_stale(~p): ~p",
                        [MsgId, false]),
             false
     end.
@@ -158,7 +158,7 @@ is_stale(MsgId) ->
 %% message id. In this case, `stale' is returned.
 -spec graft(any()) -> stale | {ok, any()} | {error, any()}.
 graft(MsgId) ->
-    % lager:info("graft(~p)",
+    % logger:info("graft(~p)",
     %            [MsgId]),
     case ets:lookup(msgs_seen, MsgId) of
         [{MsgId, Key}] ->


### PR DESCRIPTION
Compiled on OTP 24 (actually OTP 24.1.2), removing the  lager application dependency (lager parse transform wouldn't compile on OTP 24). I replaced all the log calls to the equivalent standard Erlang logger calls.
Best regards,
Massimo